### PR TITLE
Use visibility("default") attribute for libc overrides

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -2978,7 +2978,7 @@ JEMALLOC_EXPORT void *(*__memalign_hook)(size_t alignment, size_t size) =
  * be implemented also, so none of glibc's malloc.o functions are added to the
  * link.
  */
-#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), used))
+#    define ALIAS(je_fn)	__attribute__((alias (#je_fn), visibility("default")))
 /* To force macro expansion of je_ prefix before stringification. */
 #    define PREALIAS(je_fn)	ALIAS(je_fn)
 #    ifdef JEMALLOC_OVERRIDE___LIBC_CALLOC


### PR DESCRIPTION
Prevents the linker from failing to override host libc functions. I'm guessing `attribute((used))` is purely a compiler directive, whereas the linker only considers visibility (which is set to `hidden` by default in our build configuration).

Upstream jemalloc still uses `attribute((used))`, and so did [old versions of tcmalloc](https://github.com/chromium/chromium/blob/84ce36326b9e2985278ae1ac8095b4b85a0653a7/third_party/tcmalloc/chromium/src/libc_override_gcc_and_weak.h#L58). However, [recent versions of tcmalloc](https://github.com/google/tcmalloc/blob/98b28bc6861036aabd1bd8d3b17800012c4d8f23/tcmalloc/libc_override_gcc_and_weak.h#L35-L36) and [mimalloc](https://github.com/microsoft/mimalloc/blob/0560fc27c08d28d523b7f741a42deb26cd01c0c6/src/alloc-override.c#L33-L38) both adjust the visibility, so this seems like a reasonable way to follow.
