### PR TITLE
Allocate from the top down on windows

### DIFF
--- a/src/pages.c
+++ b/src/pages.c
@@ -133,7 +133,7 @@ os_pages_map(void *addr, size_t size, size_t alignment, bool *commit) {
 	 * If VirtualAlloc can't allocate at the given address when one is
 	 * given, it fails and returns NULL.
 	 */
-	ret = VirtualAlloc(addr, size, MEM_RESERVE | (*commit ? MEM_COMMIT : 0),
+	ret = VirtualAlloc(addr, size, MEM_RESERVE | (*commit ? MEM_COMMIT : 0) | MEM_TOP_DOWN,
 	    PAGE_READWRITE);
 #else
 	/*


### PR DESCRIPTION
FEX allocations can get in the way of allocations that are 4gb-limited even in 64-bit mode (i.e. those from LuaJIT), so allocate starting from the top of the AS to prevent conflicts.