### PR TITLE
Always build as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,4 +121,4 @@ function(AddLibrary Name Type)
   target_compile_options(${Name} PRIVATE -fvisibility=hidden)
 endfunction()
 
-AddLibrary(${PROJECT_NAME} OBJECT)
+AddLibrary(${PROJECT_NAME} STATIC)


### PR DESCRIPTION
This should have the same effect as an OBJECT library while making CMake's dependency propagation more reliable.