### PR TITLE
[cmake] use `MINGW` builtin instead of custom `MINGW_BUILD`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,66 +42,65 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/include/jemalloc/jemalloc_defs.h)
 
 set (SRCS
-src/jemalloc.c
-src/arena.c
-src/background_thread.c
-src/base.c
-src/bin.c
-src/bitmap.c
-src/ckh.c
-src/ctl.c
-src/div.c
-src/extent.c
-src/extent_dss.c
-src/extent_mmap.c
-src/hook.c
-src/large.c
-src/log.c
-src/malloc_io.c
-src/mutex.c
-src/nstime.c
-src/pages.c
-src/prof.c
-src/rtree.c
-src/safety_check.c
-src/stats.c
-src/sc.c
-src/sz.c
-src/tcache.c
-src/test_hooks.c
-src/ticker.c
-src/tsd.c
-src/witness.c
-src/pa.c
-src/pac.c
-src/eset.c
-src/edata.c
-src/sec.c
-src/decay.c
-src/hpa_hooks.c
-src/pa_extra.c
-src/ehooks.c
-src/inspect.c
-src/emap.c
-src/san.c
-src/prof_data.c
-src/counter.c
-src/cache_bin.c
-src/thread_event.c
-src/fxp.c
-src/ecache.c
-src/edata_cache.c
-src/pai.c
-src/exp_grow.c
-src/hpa.c
-src/hpdata.c
-src/psset.c
-src/peak_event.c
-src/buf_writer.c
-src/prof_recent.c
-src/san_bump.c
-src/bin_info.c
-)
+  src/jemalloc.c
+  src/arena.c
+  src/background_thread.c
+  src/base.c
+  src/bin.c
+  src/bitmap.c
+  src/ckh.c
+  src/ctl.c
+  src/div.c
+  src/extent.c
+  src/extent_dss.c
+  src/extent_mmap.c
+  src/hook.c
+  src/large.c
+  src/log.c
+  src/malloc_io.c
+  src/mutex.c
+  src/nstime.c
+  src/pages.c
+  src/prof.c
+  src/rtree.c
+  src/safety_check.c
+  src/stats.c
+  src/sc.c
+  src/sz.c
+  src/tcache.c
+  src/test_hooks.c
+  src/ticker.c
+  src/tsd.c
+  src/witness.c
+  src/pa.c
+  src/pac.c
+  src/eset.c
+  src/edata.c
+  src/sec.c
+  src/decay.c
+  src/hpa_hooks.c
+  src/pa_extra.c
+  src/ehooks.c
+  src/inspect.c
+  src/emap.c
+  src/san.c
+  src/prof_data.c
+  src/counter.c
+  src/cache_bin.c
+  src/thread_event.c
+  src/fxp.c
+  src/ecache.c
+  src/edata_cache.c
+  src/pai.c
+  src/exp_grow.c
+  src/hpa.c
+  src/hpdata.c
+  src/psset.c
+  src/peak_event.c
+  src/buf_writer.c
+  src/prof_recent.c
+  src/san_bump.c
+  src/bin_info.c)
 
 function(AddLibrary Name Type)
   add_library(${Name} ${Type} ${SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,15 @@ include(CheckPIESupported)
 check_pie_supported()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-if (MINGW_BUILD)
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/pregen-win32/include/)
-else()
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/pregen/include/)
+
+set(pregen pregen)
+if (MINGW)
+  set(pregen pregen-win32)
 endif()
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/)
+
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/${pregen}/include/
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 
 include(CheckCSourceCompiles)
 check_c_source_compiles(
@@ -107,14 +110,14 @@ function(AddLibrary Name Type)
 
   set_target_properties(${Name} PROPERTIES OUTPUT_NAME FEX_jemalloc)
 
-  target_include_directories(${Name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/)
-  if (MINGW_BUILD)
-    target_include_directories(${Name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/pregen-win32/include/)
-  else()
+  target_include_directories(${Name} PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/${pregen}/include/
+    ${CMAKE_CURRENT_BINARY_DIR}/include/)
+
+  if (NOT MINGW)
     target_link_libraries(${Name} pthread)
-    target_include_directories(${Name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/pregen/include/)
   endif()
-  target_include_directories(${Name} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include/)
 
   target_compile_definitions(${Name} PRIVATE -D_GNU_SOURCE -D_REENTRANT)
 


### PR DESCRIPTION
Signed-off-by: crueter <crueter@eden-emu.dev>
