### PR TITLE
use strerror_r wrapper only for glibc

### DIFF
--- a/src/malloc_io.c
+++ b/src/malloc_io.c
@@ -96,7 +96,9 @@ buferror(int err, char *buf, size_t buflen) {
 	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0,
 	    (LPSTR)buf, (DWORD)buflen, NULL);
 	return 0;
-#elif defined(JEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE) && defined(_GNU_SOURCE)
+#elif defined(JEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE) \
+   && defined(_GNU_SOURCE) \
+   && defined(__GLIBC__)
 	char *b = strerror_r(err, buf, buflen);
 	if (b != buf) {
 		strncpy(buf, b, buflen);


### PR DESCRIPTION
Compiling with clang/musl from FEX fails with:

```
FEX/External/jemalloc_glibc/src/malloc_io.c:100:8: error: incompatible integer to pointer conversion initializing 'char *' with an expression of type 'int' [-Wint-conversion]
  100 |         char *b = strerror_r(err, buf, buflen);
      |               ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Add check for `__GLIBC__` to the wrapper code to only use it with glibc, which provides a non-standard `strerror_r()` when `_GNU_SOURCE` is defined

fixes: FEX-Emu/FEX#5106