### PR TITLE
Use proper type `pthread_t` for NO_INITIALIZER macro

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -197,7 +197,7 @@ static uint8_t	malloc_slow_flags;
 
 #ifdef JEMALLOC_THREADED_INIT
 /* Used to let the initializing thread recursively allocate. */
-#  define NO_INITIALIZER	((unsigned long)0)
+#  define NO_INITIALIZER	((pthread_t)NULL)
 #  define INITIALIZER		pthread_self()
 #  define IS_INITIALIZER	(malloc_initializer == pthread_self())
 static pthread_t		malloc_initializer = NO_INITIALIZER;


### PR DESCRIPTION
builing with clang causes a warning due to type mismatch:

```
[159/335] Building C object External/jemalloc_glibc/CMakeFiles/FEX_jemalloc_glibc.dir/src/jemalloc.c.o
FEX/External/jemalloc_glibc/src/jemalloc.c:203:40: warning: expression which evaluates to zero treated as a null pointer constant of type 'pthread_t' (aka 'struct __pthread *') [-Wnon-literal-null-conversion]
  203 | static pthread_t                malloc_initializer = NO_INITIALIZER;
      |                                                      ^~~~~~~~~~~~~~
/home/pepper/dev/ghrepos/FEX/External/jemalloc_glibc/src/jemalloc.c:200:26: note: expanded from macro 'NO_INITIALIZER'
  200 | #  define NO_INITIALIZER        ((unsigned long)0)
      |                                 ^~~~~~~~~~~~~~~~~~
1 warning generated.
```

Use proper definition to handle the warning.